### PR TITLE
Add IP listening option

### DIFF
--- a/config.conf
+++ b/config.conf
@@ -4,7 +4,8 @@ const whitelist = ['127.0.0.1','192.168.0.*']; //Example for add several IP in w
 const whitelistMode = false; //Disabling enabling the ip whitelist mode. true/false
 const autorun = true; //Autorun in the browser. true/false
 const enableExtensions = true; //Enables support for TavernAI-extras project
+const listen = true; // If true, Can be access from other device or PC. otherwise can be access only from hosting machine.
 
 module.exports = {
-  port, whitelist, whitelistMode, autorun, enableExtensions,
+  port, whitelist, whitelistMode, autorun, enableExtensions, listen
 };

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ const whitelist = config.whitelist;
 const whitelistMode = config.whitelistMode;
 const autorun = config.autorun;
 const enableExtensions = config.enableExtensions;
-
+const listen = config.listen;
 
 var Client = require('node-rest-client').Client;
 var client = new Client();
@@ -1536,7 +1536,7 @@ function getAsync(url, args) {
 }
 // ** END **
 
-app.listen(server_port, function () {
+app.listen(server_port, (listen ? '0.0.0.0' : '127.0.0.1'), function () {
     if (process.env.colab !== undefined) {
         if (process.env.colab == 2) {
             is_colab = true;


### PR DESCRIPTION
# Summary
Add IP Listening options.

If `config.listen` is `false`, user can be access only from hosting machine.